### PR TITLE
Merchant bulk discount edit

### DIFF
--- a/app/controllers/bulk_discounts_controller.rb
+++ b/app/controllers/bulk_discounts_controller.rb
@@ -30,6 +30,23 @@ class BulkDiscountsController < ApplicationController
   end
 
   def edit
+    @bulk_discount = BulkDiscount.find(params[:id])
+  end
+
+  def update
+    @bulk_discount = BulkDiscount.find(params[:id])
+
+    if bulk_discount_params[:percent_discount].to_i > 100
+
+      redirect_to edit_merchant_bulk_discount_path(@bulk_discount.merchant,@bulk_discount), notice: "Please enter a number under 100 for percentage"
+
+    else
+
+      @bulk_discount.update(percent_discount: bulk_discount_params[:percent_discount], quantity_threshold: bulk_discount_params[:quantity_threshold])
+
+      redirect_to merchant_bulk_discount_path(@bulk_discount.merchant,@bulk_discount)
+
+    end
   end
 
   def destroy

--- a/app/controllers/bulk_discounts_controller.rb
+++ b/app/controllers/bulk_discounts_controller.rb
@@ -29,6 +29,9 @@ class BulkDiscountsController < ApplicationController
     end
   end
 
+  def edit
+  end
+
   def destroy
     bulk_discount = BulkDiscount.find(params[:id])
     bulk_discount.destroy

--- a/app/views/bulk_discounts/edit.html.erb
+++ b/app/views/bulk_discounts/edit.html.erb
@@ -1,1 +1,9 @@
 <h1> bulk discount edit form </h1>
+
+<%= form_with url: merchant_bulk_discount_path(@bulk_discount.id), method: :patch, local: true do |form|%>
+  <%=form.label :percent_discount, "Percent Discount" %>
+  <%=form.number_field :percent_discount, value: @bulk_discount.percent_discount%>
+  <%=form.label :quantity_threshold, "Quantity Threshold" %>
+  <%=form.number_field :quantity_threshold, value: @bulk_discount.quantity_threshold%>
+  <%=form.submit "Submit" %>
+<% end %>

--- a/app/views/bulk_discounts/edit.html.erb
+++ b/app/views/bulk_discounts/edit.html.erb
@@ -1,0 +1,1 @@
+<h1> bulk discount edit form </h1>

--- a/app/views/bulk_discounts/show.html.erb
+++ b/app/views/bulk_discounts/show.html.erb
@@ -7,3 +7,7 @@
 <p>
   Quantity Threshold: <%= @bulk_discount.quantity_threshold%>
 </p>
+
+<p>
+  <%= link_to "Edit Discount", edit_merchant_bulk_discount_path(@bulk_discount.merchant,@bulk_discount), class: "edit-discount-link"%>
+</p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,7 +21,7 @@ Rails.application.routes.draw do
   resources :merchants, only: %i[show update new] do
     resources :invoices, controller: 'merchant_invoices', only: %i[index show update]
     resources :items, controller: 'merchant_items', only: %i[index edit show update new create]
-    resources :bulk_discounts, controller: 'bulk_discounts', only: %i[index show new create destroy]
+    resources :bulk_discounts, controller: 'bulk_discounts', only: %i[index show new create edit destroy]
   end
 
   resources :admin, only: [:index]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,7 +21,7 @@ Rails.application.routes.draw do
   resources :merchants, only: %i[show update new] do
     resources :invoices, controller: 'merchant_invoices', only: %i[index show update]
     resources :items, controller: 'merchant_items', only: %i[index edit show update new create]
-    resources :bulk_discounts, controller: 'bulk_discounts', only: %i[index show new create edit destroy]
+    resources :bulk_discounts, controller: 'bulk_discounts', only: %i[index show new create edit update destroy]
   end
 
   resources :admin, only: [:index]

--- a/spec/features/merchants/bulk_discounts/edit_spec.rb
+++ b/spec/features/merchants/bulk_discounts/edit_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+
+RSpec.describe 'merchant bulk discount edit page' do
+  it 'is pre-filled with the current discount attributes' do
+    merchant1 = Merchant.create!(name: "Snake Shop")
+
+      bulk_discount1 = BulkDiscount.create!(percent_discount: 10, quantity_threshold: 5, merchant_id: merchant1.id)
+      bulk_discount2 = BulkDiscount.create!(percent_discount: 20, quantity_threshold: 10, merchant_id: merchant1.id)
+
+      visit edit_merchant_bulk_discount_path(bulk_discount1.merchant,bulk_discount1)
+
+      expect(page).to have_field("Percent Discount", with: 10)
+      expect(page).to have_field("Quantity Threshold", with: 5)
+  end
+
+  it 'when information is changed and submitted, redirects to the discount\'s show page and see the updated information' do
+    merchant1 = Merchant.create!(name: "Snake Shop")
+
+      bulk_discount1 = BulkDiscount.create!(percent_discount: 10, quantity_threshold: 5, merchant_id: merchant1.id)
+
+    visit edit_merchant_bulk_discount_path(bulk_discount1.merchant,bulk_discount1)
+
+    fill_in "Percent Discount", with: 90
+    fill_in "Quantity Threshold", with: 30
+
+    click_on "Submit"
+
+    expect(current_path).to eq("/merchants/#{merchant1.id}/bulk_discounts/#{bulk_discount1.id}")
+
+    expect(page).to have_content("Percent Discount: 90%")
+    expect(page).to have_content("Quantity Threshold: 30")
+  end
+
+  it 'rejects update if discount is over 100' do
+    merchant1 = Merchant.create!(name: "Snake Shop")
+
+      bulk_discount1 = BulkDiscount.create!(percent_discount: 10, quantity_threshold: 5, merchant_id: merchant1.id)
+
+    visit edit_merchant_bulk_discount_path(bulk_discount1.merchant,bulk_discount1)
+
+    fill_in "Percent Discount", with: 110
+
+    click_on "Submit"
+
+    expect(current_path).to eq(edit_merchant_bulk_discount_path(bulk_discount1.merchant,bulk_discount1))
+
+    expect(page).to have_content("Please enter a number under 100 for percentage")
+  end
+end

--- a/spec/features/merchants/bulk_discounts/show_spec.rb
+++ b/spec/features/merchants/bulk_discounts/show_spec.rb
@@ -17,4 +17,32 @@ RSpec.describe 'merchant bulk discount show page' do
     expect(page).to_not have_content("Quantity Threshold: 10")
   end
 
+  it 'has a link to edit the bulk discount' do
+  
+    merchant1 = Merchant.create!(name: "Snake Shop")
+
+      bulk_discount1 = BulkDiscount.create!(percent_discount: 10, quantity_threshold: 5, merchant_id: merchant1.id)
+      bulk_discount2 = BulkDiscount.create!(percent_discount: 20, quantity_threshold: 10, merchant_id: merchant1.id)
+      
+      visit "/merchants/#{merchant1.id}/bulk_discounts/#{bulk_discount1.id}"
+
+      click_on "Edit Discount"
+
+      expect(current_path).to eq(edit_merchant_bulk_discount_path(bulk_discount1.merchant,bulk_discount1))
+  end
 end
+
+
+# Merchant Bulk Discount Edit
+
+# As a merchant
+# When I visit my bulk discount show page
+# Then I see a link to edit the bulk discount
+# When I click this link
+# Then I am taken to a new page with a form to edit the discount
+
+
+# And I see that the discounts current attributes are pre-poluated in the form
+# When I change any/all of the information and click submit
+# Then I am redirected to the bulk discount's show page
+# And I see that the discount's attributes have been updated


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Does this complete sad-path testing if relevant?


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

- Feature

**What is the new behavior (if this is a feature change)?**

> Merchant Bulk Discount Edit
> 
> As a merchant
> When I visit my bulk discount show page
> Then I see a link to edit the bulk discount
> When I click this link
> Then I am taken to a new page with a form to edit the discount
> And I see that the discounts current attributes are pre-poluated in the form
> When I change any/all of the information and click submit
> Then I am redirected to the bulk discount's show page
> And I see that the discount's attributes have been updated

- If user enters number over 100, they are redirected back to the update page and told to try again. They can enter 100, because if they want to give it away, that's on them. 

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

- No

**Other information**:

- Completes "Merchant Bulk Discount Edit" user story